### PR TITLE
テキスト化のロジックの修正

### DIFF
--- a/src/blob_operations.py
+++ b/src/blob_operations.py
@@ -40,12 +40,3 @@ def upload_blob(bucket_name, source_file_name, destination_blob_name):
             unit_divisor=1024) as pbar:
         blob.upload_from_file(file_obj)
         pbar.update(blob_size)
-
-def append_to_skipped_files(file_name):
-    skipped_file_path = os.path.join(os.path.dirname(__file__), '..', 'target', 'skipped.csv')
-    os.makedirs(os.path.dirname(skipped_file_path), exist_ok=True)
-    
-    with open(skipped_file_path, 'a') as csvfile:
-        if os.stat(skipped_file_path).st_size == 0:
-            csvfile.write("file_name\n")
-        csvfile.write(f"{file_name}\n")

--- a/src/data_analysis.py
+++ b/src/data_analysis.py
@@ -6,14 +6,20 @@ from blob_operations import download_blob_as_string, upload_blob
 from sentence_analysis import analyze_text_sentences
 
 def analyze_and_upload(batch_name, bucket_name, valid_files, pbar):
+    if batch_name is None or bucket_name is None:
+        raise ValueError("batch_name and bucket_name must not be None")
+
     tmp_root = "./tmp"
-    os.makedirs(tmp_root, exist_ok=True) 
+    os.makedirs(tmp_root, exist_ok=True)
     table_list = []
     error_log_path = os.path.join(tmp_root, "errors.log")
 
     for file_name in valid_files:
+        if file_name is None:
+            continue  # Skip if file_name is None
+
+        blob_path = f"xml_files/{batch_name}/{file_name}"
         try:
-            blob_path = f"xml_files/{batch_name}/{file_name}"
             xml_string = download_blob_as_string(bucket_name, blob_path)
             text = analyze_text_sentences(xml_string)
             if not text:
@@ -22,23 +28,21 @@ def analyze_and_upload(batch_name, bucket_name, valid_files, pbar):
             # DEBUG: tmpディレクトリにテキストファイルを保存
             # with open(f"./tmp/{str(file_name).replace('.xml', '.txt')}", "w") as text_file:
             #     text_file.write(text)
-
             df = pd.DataFrame([text], columns=["Text"])
             table = pa.Table.from_pandas(df)
             table_list.append(table)
-
+            
         except Exception as e:
-            error_msg = str(e)
-            full_msg = f"Error processing {blob_path}: {error_msg}\n"
+            error_msg = f"{str(e)} | batch_name: {batch_name}, bucket_name: {bucket_name}, file_name: {file_name}"
             with open(error_log_path, "a") as error_log:
-                error_log.write(full_msg)
-            continue  # 処理を続行
+                error_log.write(f"Error processing {blob_path}: {error_msg}\n")
+            continue
         finally:
-            pbar.update(1)  # プログレスバーを更新
+            pbar.update(1)
 
     if table_list:
         combined_table = pa.concat_tables(table_list)
         tmp_output_path = os.path.join(tmp_root, f"{batch_name}.parquet")
         pq.write_table(combined_table, tmp_output_path)
-        
+
         upload_blob(bucket_name, tmp_output_path, f"parquet_files/{batch_name}/{batch_name}.parquet")

--- a/src/main.py
+++ b/src/main.py
@@ -3,9 +3,8 @@ warnings.simplefilter(action='ignore', category=FutureWarning)
 
 import os
 from google.cloud import storage
-import apache_beam as beam
 from data_analysis import analyze_and_upload
-from pipeline_setup import setup_pipeline_args, configure_pipeline_options
+from pipeline_setup import setup_pipeline_args
 import pandas as pd
 from tqdm import tqdm
 

--- a/src/pipeline_setup.py
+++ b/src/pipeline_setup.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 from apache_beam.options.pipeline_options import PipelineOptions, GoogleCloudOptions, WorkerOptions
 
 def setup_pipeline_args(argv=None):

--- a/src/sentence_analysis.py
+++ b/src/sentence_analysis.py
@@ -1,16 +1,19 @@
-import spacy
 from text_extraction import extract_abstract_and_body_text
 
-# TODO: 精度向上のため、ロードするモデルの変更を検討する
-# TODO: 軽量化のため、不要なパイプラインコンポーネントの非活性化を検討する
-nlp = spacy.load("en_core_sci_lg-0.5.4/en_core_sci_lg/en_core_sci_lg-0.5.4", disable=[])
-nlp.add_pipe("sentencizer")
-
-def count_text_sentences(text):
-    doc = nlp(text)
-    return len(list(doc.sents))
-
-def analyze_text_sentences(file_path):
-    abstract_text, body_text = extract_abstract_and_body_text(file_path)
-    combined_text = f"{abstract_text}\n\n{body_text}"
+def analyze_text_sentences(xml_string):
+    abstract_text, body_text = extract_abstract_and_body_text(xml_string)
+    
+    ## abstract_textがある && body_textがある → # Abstract \n {abstract_text} \n # Body \n {body_text}
+    ## abstract_textがある && body_textがない → # Abstract \n {abstract_text}
+    ## abstract_textがない && body_textがある → # Body \n {body_text}
+    ## abstract_textがない && body_textがない → 空文字列
+    if abstract_text and body_text:
+        combined_text = f"# Abstract\n{abstract_text}\n\n# Body\n{body_text}"
+    elif abstract_text:
+        combined_text = f"# Abstract\n{abstract_text}"
+    elif body_text:
+        combined_text = f"# Body\n{body_text}"
+    else:
+        combined_text = ""
+    
     return combined_text

--- a/src/sentence_analysis.py
+++ b/src/sentence_analysis.py
@@ -2,11 +2,12 @@ from text_extraction import extract_abstract_and_body_text
 
 def analyze_text_sentences(xml_string):
     abstract_text, body_text = extract_abstract_and_body_text(xml_string)
-    
-    ## abstract_textがある && body_textがある → # Abstract \n {abstract_text} \n # Body \n {body_text}
-    ## abstract_textがある && body_textがない → # Abstract \n {abstract_text}
-    ## abstract_textがない && body_textがある → # Body \n {body_text}
-    ## abstract_textがない && body_textがない → 空文字列
+
+    # Replace None with empty strings if necessary
+    abstract_text = "" if abstract_text is None else abstract_text
+    body_text = "" if body_text is None else body_text
+
+    # Construct the combined text based on content availability
     if abstract_text and body_text:
         combined_text = f"# Abstract\n{abstract_text}\n\n# Body\n{body_text}"
     elif abstract_text:

--- a/src/text_extraction.py
+++ b/src/text_extraction.py
@@ -1,12 +1,49 @@
 import xml.etree.ElementTree as ET
 
-def extract_abstract_and_body_text(file_path):
+def extract_abstract_and_body_text(xml_string):
     try:
-        tree = ET.parse(file_path)
-        root = tree.getroot()
-        abstract_text = "".join(root.find('.//front/article-meta/abstract').itertext()) if root.find('.//front/article-meta/abstract') is not None else ""
-        body_text = "".join(root.find('.//body').itertext()) if root.find('.//body') is not None else ""
+        root = ET.fromstring(xml_string) 
+        # Extract abstract and body sections
+        abstract_section = root.find('.//front/article-meta/abstract')
+        body_section = root.find('.//body')
+        
+        # Convert extracted sections to Markdown
+        abstract_text = xml_to_markdown(ET.tostring(abstract_section, encoding='unicode')) if abstract_section is not None else ""
+        body_text = xml_to_markdown(ET.tostring(body_section, encoding='unicode')) if body_section is not None else ""
+
         return abstract_text, body_text
-    except Exception as e:
-        print(f"Error processing file {file_path}: {e}")
+    except ET.ParseError as e:
+        print(f"Failed to parse XML: {e}")
         return "", ""
+
+def xml_to_markdown(xml_string):
+    def process_element(element, parent_tag=None):
+        md = ""
+        if element.tag == 'sec':
+            title_element = element.find('title')
+            if title_element is not None:
+                md += "## " + title_element.text + "\n\n"
+            for child in element:
+                if child.tag != 'title':
+                    md += process_element(child, parent_tag=element.tag)
+        elif element.tag == 'title' and parent_tag != 'sec':
+            md += "### " + element.text + "\n\n"
+        elif element.tag == 'p':
+            md += ''.join(element.itertext()).strip() + "\n\n"
+        elif element.tag == 'bold':
+            md += "**" + (element.text or '') + "**"
+        elif element.tag == 'italic':
+            md += "*" + (element.text or '') + "*"
+        elif element.tag == 'xref':
+            pass
+        elif element.tag == 'fig':
+            pass
+        return md
+
+    # Parse the XML string
+    root = ET.fromstring(xml_string)
+    markdown = ""
+    for child in root:
+        markdown += process_element(child)
+    
+    return markdown.strip()  # Remove leading/trailing whitespace


### PR DESCRIPTION
- テキスト化する際にタグを改行に置き換えるアルゴリズムだったが、markdownに変換するように修正した
- parquetをbatchごとに出力されるようにした
- 不要な実装を除去した
- エラーハンドリングの追加